### PR TITLE
fix `minikube start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To ensure a smooth Installfest, please make sure your local environment is set u
 
 ### Preparing for the event
 
-- Please run `minikube start --network-plugin=cni` a few hours / days before the Installfest in order to download Minikube images, which can take some time.
+- Please run `minikube start --network-plugin=cni --cni=false --kubernetes-version=1.21.6` a few hours / days before the Installfest in order to download Minikube images, which can take some time.
 - [Download](https://github.com/cilium/installfest/archive/refs/heads/main.zip) or `git clone` this repository to have a local copy of the resources used during the Installfest.
 - Make sure to have your computer fully charged or plugged in, internet connection up and running, water and snacks at your disposal, and make yourself comfortable :)
 

--- a/installfest/README.md
+++ b/installfest/README.md
@@ -5,7 +5,7 @@ Documentation: https://minikube.sigs.k8s.io/docs/commands/start/
 Run the following command to set up your local Minikube cluster:
 
 ```sh
-minikube start --network-plugin=cni
+minikube start --network-plugin=cni --cni=false --kubernetes-version=1.21.6
 ```
 
 We can check that the cluster has properly started by verifying the current `kubectl` context is `minikube`:


### PR DESCRIPTION
- `--network-plugin=cni` is not enough on its own to ensure Minikube will not deploy a CNI in the cluster depending on the configuration and Minikube version, adding `--cni=false` ensure no CNI is deployed.
- Cilium 1.10 only supports Kubernetes 1.21 officially, pin K8s version accordingly.