### PR TITLE
switch to `--wait=false` for `cilium-test` delete

### DIFF
--- a/installfest/README.md
+++ b/installfest/README.md
@@ -92,7 +92,7 @@ cilium connectivity test
 Once done, clean up the connectivity test namespace:
 
 ```sh
-kubectl delete ns cilium-test&
+kubectl delete ns cilium-test --wait=false
 ```
 
 # Network Policies


### PR DESCRIPTION
Because that's just plain better than using a background job :D
Thanks Bruno for the tip.