### PR TITLE
Update required Minikube version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To ensure a smooth Installfest, please make sure your local environment is set u
 
 - Familiarity with command line usage and basic Kubernetes operations
 - A Linux or Intel-based Mac machine with `kubectl` installed: https://kubernetes.io/docs/tasks/tools/#kubectl
-- Minikube installed (>= 1.5.2): https://minikube.sigs.k8s.io/docs/start/
+- Minikube installed (>= 1.12.0): https://minikube.sigs.k8s.io/docs/start/
 
 > Note: while we strongly recommend using Minikube, the Installfest may also be followed on any GKE, EKS, or AKS cluster, though you will not get support from the staff in case of cluster-related issues during the event.
 > See our documentation for more details on preparing a GKE, EKS, or AKS cluster for Cilium: https://docs.cilium.io/en/stable/gettingstarted/


### PR DESCRIPTION
Minikube 1.12 is required to use the --cni flag [1].

1 - https://github.com/kubernetes/minikube/commit/9e95435e0020eed065ee0229a6a54a7e54530a6d